### PR TITLE
replaced /Library/Updates/index.plist check with softwareupdate --list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This framework will prompt users of Jamf-managed Macs to install Apple software 
 
 ![Install or defer prompt](img/install-or-defer-fullscreen.png)
 
-This workflow is most useful for updates that require a restart and include important security-related patches (e.g. Security Update 2017-003 or macOS 10.12.3).
+This workflow is most useful for updates that require a restart and include important security-related patches (e.g. Security Update 2018-004 Sierra, macOS High Sierra 10.13.6.)
 
-This framework is distributed in the form of a [munkipkg](https://github.com/munki/munki-pkg) project, which allows easy creation of a new pkg when changes are made to the script or to the LaunchDaemon that runs it. (Despite the name, packages generated with munkipkg don't require Munki. They work great with Casper/Jamf Pro.) See the [Installer Creation](#installer-creation) section below for specific steps on creating the installer for this framework.
+This framework is distributed in the form of a [munkipkg](https://github.com/munki/munki-pkg) project, which allows easy creation of a new pkg when changes are made to the script or to the LaunchDaemon that runs it. (Despite the name, packages generated with munkipkg don't require Munki; they work great with Jamf Pro.) See the [Installer Creation](#installer-creation) section below for specific steps on creating the installer for this framework.
 
 
 ## Requirements and assumptions
@@ -129,7 +129,7 @@ The following objects should be created on the JSS in order to implement this fr
 
 ### Packages
 
-Upload this package (created with munkipkg above) to the JSS via Casper Admin or via the JSS web app:
+Upload this package (created with munkipkg above) to the JSS via Jamf Admin or via the JSS web app:
 
 - __install_or_defer-x.x.x.pkg__
 

--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>1.0</string>
+	<string>1.1</string>
 </dict>
 </plist>


### PR DESCRIPTION
- added preflight `softwareupdate --list` (more accurate than reading from `/Library/Updates/index.plist`, with tradeoff of longer script runtime #3) before caching updates (script exits if `--list` returns no recommended results)
- set `softwareupdate --download` to only grab `--recommended` updates (as per `README` and the intent of the script to only trigger for security updates requiring restart)
- renamed `clean_up_before_restart` function to `clean_up` (since it isn't always run as part of a restart action)
- iterated version in script and `build-info.plist` to `1.1`
- updated Casper references to Jamf Pro in `README`
- updated example security patches in `README` to more recent builds (matching naming convention from [Apple security updates](https://support.apple.com/en-us/HT201222))