### PR TITLE
added shutdown workflow for BridgeOS updates

### DIFF
--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>2.1</string>
+	<string>2.1.1</string>
 </dict>
 </plist>


### PR DESCRIPTION
- added shutdown workflow for BridgeOS updates (detects string  in `softwareupdate --install --all` output indicating a shutdown is required rather than a restart, changes restart function to shut down instead) #10 
- iterated script and build-info.plist version to 2.1.1