### PR TITLE
added cleanup on fresh installs and exit_without_updating

### DIFF
--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>2.1.3</string>
+	<string>2.1.4</string>
 </dict>
 </plist>

--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -263,8 +263,11 @@ exit_without_updating () {
 
     clean_up
 
-    "/bin/echo" "Unloading $BUNDLE_ID LaunchDaemon. Script will end here."
-    "/bin/launchctl" unload -w "/private/tmp/$BUNDLE_ID.plist"
+    if [[ -e "/private/tmp/$BUNDLE_ID.plist" ]]; then
+      "/bin/echo" "Unloading $BUNDLE_ID LaunchDaemon..."
+      "/bin/launchctl" unload -w "/private/tmp/$BUNDLE_ID.plist"
+    fi
+    "/bin/echo" "Script will end here."
     exit 0
 
 }

--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -13,8 +13,8 @@
 #                   restarts automatically.
 #         Authors:  Elliot Jordan and Mario Panighetti
 #         Created:  2017-03-09
-#   Last Modified:  2019-04-11
-#         Version:  2.1.3
+#   Last Modified:  2019-05-14
+#         Version:  2.1.4
 #
 ###
 
@@ -260,6 +260,8 @@ exit_without_updating () {
 
     echo "Running jamf recon..."
     "$jamf" recon
+
+    clean_up
 
     "/bin/echo" "Unloading $BUNDLE_ID LaunchDaemon. Script will end here."
     "/bin/launchctl" unload -w "/private/tmp/$BUNDLE_ID.plist"

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -9,11 +9,11 @@ exec 1> >(logger -s -t "$(basename "$0")") 2>&1
 
 # Kill jamfHelper process to close all current notifications.
 echo "Killing any active jamfHelper notifications..."
-killall jamfHelper 2>"$3/dev/null"
+killall jamfHelper 2>"/dev/null"
 
 # Clean up plist values.
 echo "Cleaning up all stored plist values..."
-defaults delete "$PLIST"
+defaults delete "$PLIST" 2>"/dev/null"
 
 # Unload LaunchDaemons.
 if [[ -f "$HELPER_LD" ]]; then

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -1,11 +1,21 @@
 #!/bin/bash
 
-# Copy all output to the system log for diagnostic purposes.
-exec 1> >(logger -s -t "$(basename "$0")") 2>&1
-
+PLIST="$3/Library/Preferences/com.elliotjordan.install_or_defer"
 HELPER_LD="$3/private/tmp/com.elliotjordan.install_or_defer_helper.plist"
 MAIN_LD="$3/Library/LaunchDaemons/com.elliotjordan.install_or_defer.plist"
 
+# Copy all output to the system log for diagnostic purposes.
+exec 1> >(logger -s -t "$(basename "$0")") 2>&1
+
+# Kill jamfHelper process to close all current notifications.
+echo "Killing any active jamfHelper notifications..."
+killall jamfHelper 2>"$3/dev/null"
+
+# Clean up plist values.
+echo "Cleaning up all stored plist values..."
+defaults delete "$PLIST"
+
+# Unload LaunchDaemons.
 if [[ -f "$HELPER_LD" ]]; then
     echo "Unloading and removing $HELPER_LD..."
     launchctl unload -w "$HELPER_LD"


### PR DESCRIPTION
- added cleanup tasks to preinstall script and `exit_without_updating` (ensures `AppleSoftwareUpdatesForcedAfter` attribute doesn't persist between script reinstalls)
- made `$BUNDLE_ID` LaunchDaemon unload conditional on file existing
- iterated version to 2.1.4