### PR TITLE
Custom max deferral timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ The above messages use the following dynamic substitutions:
 - `MAX_DEFERRAL_TIME`
     Number of seconds between the first script run and the updates being forced.
 
+    You can customize this value (including making it a different value for multiple groups of Macs) with one or more configuration profiles setting the `MAX_DEFERRAL_TIME` attribute in `$PLIST` to a positive integer of your choice.
+
 - `EACH_DEFER`
     When the user clicks "Defer" the next prompt is delayed by this much time.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The above messages use the following dynamic substitutions:
 
     Number of seconds between the first script run and the updates being forced.
 
-    You can customize this value (including making it a different value for multiple groups of Macs) with one or more configuration profiles setting the `MAX_DEFERRAL_TIME` attribute in `$PLIST` to a positive integer of your choice.
+    You can customize this value (including making it a different value for multiple groups of Macs) with one or more configuration profiles setting the `MAX_DEFERRAL_TIME` attribute in `$PLIST` to a positive integer of your choice. To disable deferral entirely (useful for script testing purposes), set the `skipDeferral` attribute to `true`.
 
 - `EACH_DEFER`
 

--- a/README.md
+++ b/README.md
@@ -65,32 +65,41 @@ There are several variables in the script that should be customized to your orga
 ### File paths and identifiers
 
 - `PLIST`
+
     Path to a plist file that is used to store settings locally. Omit ".plist" extension.
 
 - `LOGO`
+
     (Optional) Path to a logo that will be used in messaging. Recommend 512px, PNG format. If no logo is provided, the Software Update icon will be used (as shown in the screenshots above).
 
 - `BUNDLE_ID`
+
     The identifier of the LaunchDaemon that is used to call this script, which should match the file in the __payload/Library/LaunchDaemons__ folder. Omit ".plist" extension.
 
 ### Messaging
 
 - `MSG_ACT_OR_DEFER_HEADING`
+
     The heading/title of the message users will receive when updates are available.
 
 - `MSG_ACT_OR_DEFER`
+
     The body of the message users will receive when updates are available.
 
 - `MSG_ACT_HEADING`
+
     The heading/title of the message users will receive when they must run updates immediately.
 
 - `MSG_ACT`
+
     The body of the message users will receive when they must run updates immediately.
 
 - `MSG_UPDATING_HEADING`
+
     The heading/title of the message users will receive when updates are running in the background.
 
 - `MSG_UPDATING`
+
     The body of the message users will receive when updates are running in the background.
 
 The above messages use the following dynamic substitutions:
@@ -103,17 +112,21 @@ The above messages use the following dynamic substitutions:
 ### Timing
 
 - `MAX_DEFERRAL_TIME`
+
     Number of seconds between the first script run and the updates being forced.
 
     You can customize this value (including making it a different value for multiple groups of Macs) with one or more configuration profiles setting the `MAX_DEFERRAL_TIME` attribute in `$PLIST` to a positive integer of your choice.
 
 - `EACH_DEFER`
+
     When the user clicks "Defer" the next prompt is delayed by this much time.
 
 - `UPDATE_DELAY`
+
     The number of seconds to wait between displaying the "run updates" message and applying updates, then attempting a soft restart.
 
 - `HARD_RESTART_DELAY`
+
     The number of seconds to wait between attempting a soft restart and forcing a restart.
 
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The above messages use the following dynamic substitutions:
 
     Number of seconds between the first script run and the updates being forced.
 
-    You can customize this value (including making it a different value for multiple groups of Macs) with one or more configuration profiles setting the `MaxDeferralTime` attribute in `$PLIST` to a positive integer of your choice. To disable deferral entirely (useful for script testing purposes), set the `skipDeferral` attribute to `true`.
+    You can customize this value (including making it a different value for multiple groups of Macs) with one or more configuration profiles setting the `MaxDeferralTime` attribute in `$PLIST` to a positive integer of your choice. To disable deferral entirely (useful for script testing purposes), set the `SkipDeferral` attribute to `true`.
 
 - `EACH_DEFER`
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The above messages use the following dynamic substitutions:
 
     Number of seconds between the first script run and the updates being forced.
 
-    You can customize this value (including making it a different value for multiple groups of Macs) with one or more configuration profiles setting the `MAX_DEFERRAL_TIME` attribute in `$PLIST` to a positive integer of your choice. To disable deferral entirely (useful for script testing purposes), set the `skipDeferral` attribute to `true`.
+    You can customize this value (including making it a different value for multiple groups of Macs) with one or more configuration profiles setting the `MaxDeferralTime` attribute in `$PLIST` to a positive integer of your choice. To disable deferral entirely (useful for script testing purposes), set the `skipDeferral` attribute to `true`.
 
 - `EACH_DEFER`
 

--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>2.1.4</string>
+	<string>2.2</string>
 </dict>
 </plist>

--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -374,14 +374,14 @@ fi
 # choice.
 skipDeferral=$(python -c "import CoreFoundation; print(CoreFoundation.CFPreferencesCopyAppValue('SkipDeferral', 'com.elliotjordan.install_or_defer'))" 2>/dev/null)
 if [[ "$skipDeferral" = "True" ]]; then
-  MAX_DEFERRAL_TIME=0
+    MAX_DEFERRAL_TIME=0
 else
-  MAX_DEFERRAL_TIME_CUSTOM=$(python -c "import CoreFoundation; print(CoreFoundation.CFPreferencesCopyAppValue('MAX_DEFERRAL_TIME', 'com.elliotjordan.install_or_defer'))" 2>/dev/null)
-  if (( MAX_DEFERRAL_TIME_CUSTOM > 0 )); then
-      MAX_DEFERRAL_TIME="$MAX_DEFERRAL_TIME_CUSTOM"
-  else
-      echo "Max deferral time undefined, or not set to a positive integer. Using default value."
-  fi
+    MAX_DEFERRAL_TIME_CUSTOM=$(python -c "import CoreFoundation; print(CoreFoundation.CFPreferencesCopyAppValue('MAX_DEFERRAL_TIME', 'com.elliotjordan.install_or_defer'))" 2>/dev/null)
+    if (( MAX_DEFERRAL_TIME_CUSTOM > 0 )); then
+        MAX_DEFERRAL_TIME="$MAX_DEFERRAL_TIME_CUSTOM"
+    else
+        echo "Max deferral time undefined, or not set to a positive integer. Using default value."
+    fi
 fi
 echo "Maximum deferral time: $(convert_seconds $MAX_DEFERRAL_TIME)"
 

--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -72,16 +72,7 @@ MSG_UPDATING="Running system updates in the background.<< Your Mac will restart 
 #################################### TIMING ###################################
 
 # Number of seconds between the first script run and the updates being forced.
-# To set this to a custom value, make a configuration profile enforcing the
-# MAX_DEFERRAL_TIME attribute in $PLIST to a positive integer of your choice.
-MAX_DEFERRAL_TIME_PLIST=$(defaults read "$PLIST" MAX_DEFERRAL_TIME 2>/dev/null)
-if (( MAX_DEFERRAL_TIME_PLIST <= 0 )); then
-    echo "Max deferral time undefined, or not set to a positive integer. Setting to default value."
-    MAX_DEFERRAL_TIME=$(( 60 * 60 * 24 * 3 )) # (259200 = 3 days)
-else
-    MAX_DEFERRAL_TIME="$MAX_DEFERRAL_TIME_PLIST"
-fi
-echo "Maximum deferral time: $(convert_seconds $MAX_DEFERRAL_TIME)"
+MAX_DEFERRAL_TIME=$(( 60 * 60 * 24 * 3 )) # (259200 = 3 days)
 
 # When the user clicks "Defer" the next prompt is delayed by this much time.
 EACH_DEFER=$(( 60 * 60 * 4 )) # (14400 = 4 hours)
@@ -370,6 +361,17 @@ if [[ -z "$LOGO" ]] || [[ ! -f "$LOGO" ]]; then
     echo "No logo provided, or no logo exists at specified path. Using Software Update icon."
     LOGO="/System/Library/CoreServices/Software Update.app/Contents/Resources/SoftwareUpdate.icns"
 fi
+
+# Validate max deferral time. To set this to a custom value, make a
+# configuration profile enforcing the MAX_DEFERRAL_TIME attribute in $PLIST to
+# a positive integer of your choice.
+MAX_DEFERRAL_TIME_PLIST=$(defaults read "$PLIST" MAX_DEFERRAL_TIME 2>/dev/null)
+if (( MAX_DEFERRAL_TIME_PLIST <= 0 )); then
+    echo "Max deferral time undefined, or not set to a positive integer. Using default value."
+else
+    MAX_DEFERRAL_TIME="$MAX_DEFERRAL_TIME_PLIST"
+fi
+echo "Maximum deferral time: $(convert_seconds $MAX_DEFERRAL_TIME)"
 
 # Perform first run tasks, including calculating deadline.
 FORCE_DATE=$(defaults read "$PLIST" AppleSoftwareUpdatesForcedAfter 2>/dev/null)

--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -13,8 +13,8 @@
 #                   restarts automatically.
 #         Authors:  Elliot Jordan and Mario Panighetti
 #         Created:  2017-03-09
-#   Last Modified:  2019-05-14
-#         Version:  2.1.4
+#   Last Modified:  2019-05-15
+#         Version:  2.2
 #
 ###
 
@@ -72,7 +72,12 @@ MSG_UPDATING="Running system updates in the background.<< Your Mac will restart 
 #################################### TIMING ###################################
 
 # Number of seconds between the first script run and the updates being forced.
-MAX_DEFERRAL_TIME=$(( 60 * 60 * 24 * 3 )) # (259200 = 3 days)
+MAX_DEFERRAL_TIME=$(defaults read "$PLIST" MaxDeferralTime 2>/dev/null)
+if (( MAX_DEFERRAL_TIME <= 0 )); then
+    echo "Max deferral time must be a positive integer. Setting to default value."
+    MAX_DEFERRAL_TIME=$(( 60 * 60 * 24 * 3 )) # (259200 = 3 days)
+fi
+echo "Maximum deferral time: $(convert_seconds $MAX_DEFERRAL_TIME)"
 
 # When the user clicks "Defer" the next prompt is delayed by this much time.
 EACH_DEFER=$(( 60 * 60 * 4 )) # (14400 = 4 hours)

--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -94,9 +94,15 @@ HARD_RESTART_DELAY=$(( 60 * 5 )) # (300 = 5 minutes)
 # Created by: perreal (http://stackoverflow.com/users/390913/perreal)
 convert_seconds () {
 
-    ((h=${1}/3600))
-    ((m=(${1}%3600)/60))
-    ((s=${1}%60))
+    if [[ $1 -eq 0 ]]; then
+        h=0
+        m=0
+        s=0
+    else
+        ((h=${1}/3600))
+        ((m=(${1}%3600)/60))
+        ((s=${1}%60))
+    fi
     printf "%02dh:%02dm:%02ds\n" $h $m $s
 
 }
@@ -366,7 +372,7 @@ fi
 # configuration profile enforcing the MAX_DEFERRAL_TIME attribute in $PLIST to
 # a positive integer of your choice.
 MAX_DEFERRAL_TIME_PLIST=$(defaults read "$PLIST" MAX_DEFERRAL_TIME 2>/dev/null)
-if (( MAX_DEFERRAL_TIME_PLIST <= 0 )); then
+if (( MAX_DEFERRAL_TIME_PLIST < 0 )); then
     echo "Max deferral time undefined, or not set to a positive integer. Using default value."
 else
     MAX_DEFERRAL_TIME="$MAX_DEFERRAL_TIME_PLIST"

--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -72,10 +72,12 @@ MSG_UPDATING="Running system updates in the background.<< Your Mac will restart 
 #################################### TIMING ###################################
 
 # Number of seconds between the first script run and the updates being forced.
-MAX_DEFERRAL_TIME=$(defaults read "$PLIST" MaxDeferralTime 2>/dev/null)
-if (( MAX_DEFERRAL_TIME <= 0 )); then
-    echo "Max deferral time must be a positive integer. Setting to default value."
+MAX_DEFERRAL_TIME_PLIST=$(defaults read "$PLIST" MaxDeferralTime 2>/dev/null)
+if (( MAX_DEFERRAL_TIME_PLIST <= 0 )); then
+    echo "Max deferral time undefined, or not set to a positive integer. Setting to default value."
     MAX_DEFERRAL_TIME=$(( 60 * 60 * 24 * 3 )) # (259200 = 3 days)
+else
+    MAX_DEFERRAL_TIME="$MAX_DEFERRAL_TIME_PLIST"
 fi
 echo "Maximum deferral time: $(convert_seconds $MAX_DEFERRAL_TIME)"
 

--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -13,7 +13,7 @@
 #                   restarts automatically.
 #         Authors:  Elliot Jordan and Mario Panighetti
 #         Created:  2017-03-09
-#   Last Modified:  2019-05-15
+#   Last Modified:  2019-05-16
 #         Version:  2.2
 #
 ###
@@ -72,7 +72,9 @@ MSG_UPDATING="Running system updates in the background.<< Your Mac will restart 
 #################################### TIMING ###################################
 
 # Number of seconds between the first script run and the updates being forced.
-MAX_DEFERRAL_TIME_PLIST=$(defaults read "$PLIST" MaxDeferralTime 2>/dev/null)
+# To set this to a custom value, make a configuration profile enforcing the
+# MAX_DEFERRAL_TIME attribute in $PLIST to a positive integer of your choice.
+MAX_DEFERRAL_TIME_PLIST=$(defaults read "$PLIST" MAX_DEFERRAL_TIME 2>/dev/null)
 if (( MAX_DEFERRAL_TIME_PLIST <= 0 )); then
     echo "Max deferral time undefined, or not set to a positive integer. Setting to default value."
     MAX_DEFERRAL_TIME=$(( 60 * 60 * 24 * 3 )) # (259200 = 3 days)

--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -95,15 +95,15 @@ HARD_RESTART_DELAY=$(( 60 * 5 )) # (300 = 5 minutes)
 convert_seconds () {
 
     if [[ $1 -eq 0 ]]; then
-        h=0
-        m=0
-        s=0
+        HOURS=0
+        MINUTES=0
+        SECONDS=0
     else
-        ((h=${1}/3600))
-        ((m=(${1}%3600)/60))
-        ((s=${1}%60))
+        ((HOURS=${1}/3600))
+        ((MINUTES=(${1}%3600)/60))
+        ((SECONDS=${1}%60))
     fi
-    printf "%02dh:%02dm:%02ds\n" $h $m $s
+    printf "%02dh:%02dm:%02ds\n" $HOURS $MINUTES $SECONDS
 
 }
 
@@ -112,19 +112,19 @@ convert_seconds () {
 check_for_updates () {
 
     echo "Checking for pending system updates..."
-    updateCheck=$(softwareupdate --list)
+    UPDATE_CHECK=$(softwareupdate --list)
 
     # Determine whether any critical updates are available, and if any require
     # a restart. If no updates need to be installed, bail out.
-    if [[ "$updateCheck" == *"[restart]"* ]]; then
-        installWhich="all"
+    if [[ "$UPDATE_CHECK" == *"[restart]"* ]]; then
+        INSTALL_WHICH="all"
         # Remove "<<" and ">>" but leave the text between
         # (retains restart warnings).
         MSG_ACT_OR_DEFER="$(echo "$MSG_ACT_OR_DEFER" | sed 's/[\<\<|\>\>]//g')"
         MSG_ACT="$(echo "$MSG_ACT" | sed 's/[\<\<|\>\>]//g')"
         MSG_UPDATING="$(echo "$MSG_UPDATING" | sed 's/[\<\<|\>\>]//g')"
-    elif [[ "$updateCheck" == *"[recommended]"* ]]; then
-        installWhich="recommended"
+    elif [[ "$UPDATE_CHECK" == *"[recommended]"* ]]; then
+        INSTALL_WHICH="recommended"
         # Remove "<<" and ">>" including all the text between
         # (removes restart warnings).
         MSG_ACT_OR_DEFER="$(echo "$MSG_ACT_OR_DEFER" | sed 's/\<\<.*\>\>//g')"
@@ -138,8 +138,8 @@ check_for_updates () {
 
     # Download updates (all updates if a restart is required for any, otherwise
     # just recommended updates).
-    echo "Caching $installWhich system updates..."
-    softwareupdate --download --$installWhich --no-scan
+    echo "Caching $INSTALL_WHICH system updates..."
+    softwareupdate --download --$INSTALL_WHICH --no-scan
 
 }
 
@@ -150,7 +150,7 @@ display_act_msg () {
     # Create a jamfHelper script that will be called by a LaunchDaemon.
     cat << EOF > "/private/tmp/$HELPER_SCRIPT"
 #!/bin/bash
-"$jamfHelper" -windowType "utility" -windowPosition "ur" -icon "$LOGO" -title "$MSG_ACT_HEADING" -description "$MSG_ACT"
+"$JAMFHELPER" -windowType "utility" -windowPosition "ur" -icon "$LOGO" -title "$MSG_ACT_HEADING" -description "$MSG_ACT"
 EOF
     chmod +x "/private/tmp/$HELPER_SCRIPT"
 
@@ -190,17 +190,17 @@ EOF
 # Displays HUD with updating message and runs all cached updates.
 run_updates () {
 
-    echo "Running $installWhich system updates..."
-    "$jamfHelper" -windowType "hud" -windowPosition "ur" -icon "$LOGO" -title "$MSG_UPDATING_HEADING" -description "$MSG_UPDATING" -lockHUD &
-    updateOutputCapture="$(softwareupdate --install --$installWhich --no-scan 2>&1)"
+    echo "Running $INSTALL_WHICH system updates..."
+    "$JAMFHELPER" -windowType "hud" -windowPosition "ur" -icon "$LOGO" -title "$MSG_UPDATING_HEADING" -description "$MSG_UPDATING" -lockHUD &
+    UPDATE_OUTPUT_CAPTURE="$(softwareupdate --install --$INSTALL_WHICH --no-scan 2>&1)"
     echo "Finished running updates."
     killall jamfHelper 2>/dev/null
     clean_up
 
     # Trigger restart if script ran an update which requires it.
-    if [[ "$installWhich" = "all" ]]; then
+    if [[ "$INSTALL_WHICH" = "all" ]]; then
         # Shut down the Mac if BridgeOS received an update requiring it.
-        if [[ "$updateOutputCapture" =~ "select Shut Down from the Apple menu" ]]; then
+        if [[ "$UPDATE_OUTPUT_CAPTURE" =~ "select Shut Down from the Apple menu" ]]; then
             trigger_restart "shut down"
         # Otherwise, restart the Mac.
         else
@@ -265,7 +265,7 @@ trigger_restart () {
 exit_without_updating () {
 
     echo "Running jamf recon..."
-    "$jamf" recon
+    "$JAMF_BINARY" recon
 
     clean_up
 
@@ -292,16 +292,16 @@ HELPER_SCRIPT="$(basename "$0" | sed "s/.sh$//g")_helper.sh"
 BAILOUT=false
 
 # Bail out if the jamfHelper doesn't exist.
-jamfHelper="/Library/Application Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper"
-if [[ ! -x "$jamfHelper" ]]; then
+JAMFHELPER="/Library/Application Support/JAMF/bin/jamfHelper.app/Contents/MacOS/jamfHelper"
+if [[ ! -x "$JAMFHELPER" ]]; then
     echo "[ERROR] The jamfHelper binary must be present in order to run this script."
     BAILOUT=true
 fi
 
 # Bail out if the jamf binary doesn't exist.
 PATH="/usr/sbin:/usr/local/bin:$PATH"
-jamf=$(which jamf)
-if [[ -z $jamf ]]; then
+JAMF_BINARY=$(which jamf)
+if [[ -z $JAMF_BINARY ]]; then
     echo "[ERROR] The jamf binary could not be found."
     BAILOUT=true
 fi
@@ -369,14 +369,14 @@ if [[ -z "$LOGO" ]] || [[ ! -f "$LOGO" ]]; then
 fi
 
 # Validate max deferral time and whether to skip deferral. To customize these
-# values, make a configuration profile enforcing the MAX_DEFERRAL_TIME (in
+# values, make a configuration profile enforcing the MaxDeferralTime (in
 # seconds) and skipDeferral (boolean) attributes in $PLIST to settings of your
 # choice.
-skipDeferral=$(python -c "import CoreFoundation; print(CoreFoundation.CFPreferencesCopyAppValue('SkipDeferral', 'com.elliotjordan.install_or_defer'))" 2>/dev/null)
-if [[ "$skipDeferral" = "True" ]]; then
+SKIP_DEFERRAL=$(python -c "import CoreFoundation; print(CoreFoundation.CFPreferencesCopyAppValue('SkipDeferral', 'com.elliotjordan.install_or_defer'))" 2>/dev/null)
+if [[ "$SKIP_DEFERRAL" = "True" ]]; then
     MAX_DEFERRAL_TIME=0
 else
-    MAX_DEFERRAL_TIME_CUSTOM=$(python -c "import CoreFoundation; print(CoreFoundation.CFPreferencesCopyAppValue('MAX_DEFERRAL_TIME', 'com.elliotjordan.install_or_defer'))" 2>/dev/null)
+    MAX_DEFERRAL_TIME_CUSTOM=$(python -c "import CoreFoundation; print(CoreFoundation.CFPreferencesCopyAppValue('MaxDeferralTime', 'com.elliotjordan.install_or_defer'))" 2>/dev/null)
     if (( MAX_DEFERRAL_TIME_CUSTOM > 0 )); then
         MAX_DEFERRAL_TIME="$MAX_DEFERRAL_TIME_CUSTOM"
     else
@@ -438,7 +438,7 @@ if (( DEFER_TIME_LEFT > 0 )); then
 
     # Show the install/defer prompt.
     echo "Prompting to install updates now or defer..."
-    PROMPT=$("$jamfHelper" -windowType "utility" -windowPosition "ur" -icon "$LOGO" -title "$MSG_ACT_OR_DEFER_HEADING" -description "$MSG_ACT_OR_DEFER" -button1 "Run Updates" -button2 "Defer" -defaultButton 2 -timeout 3600 -startlaunchd 2>/dev/null)
+    PROMPT=$("$JAMFHELPER" -windowType "utility" -windowPosition "ur" -icon "$LOGO" -title "$MSG_ACT_OR_DEFER_HEADING" -description "$MSG_ACT_OR_DEFER" -button1 "Run Updates" -button2 "Defer" -defaultButton 2 -timeout 3600 -startlaunchd 2>/dev/null)
     JAMFHELPER_PID=$!
 
     # Make a note of the amount of time the prompt was shown onscreen.

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -13,10 +13,8 @@ killall jamfHelper 2>"/dev/null"
 
 # Clean up plist values.
 echo "Cleaning up stored plist values..."
-defaults delete "$PLIST" UpdatesForcedAfter 2>/dev/null
-defaults delete "$PLIST" UpdatesDeferredUntil 2>/dev/null
-defaults delete "$PLIST" ThirdPartyUpdatesRestartRequired 2>/dev/null
-defaults delete "$PLIST" ThirdPartyUpdatesRelaunchRequired 2>/dev/null
+defaults delete "$PLIST" AppleSoftwareUpdatesForcedAfter 2>/dev/null
+defaults delete "$PLIST" AppleSoftwareUpdatesDeferredUntil 2>/dev/null
 
 # Unload LaunchDaemons.
 if [[ -f "$HELPER_LD" ]]; then

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -12,8 +12,11 @@ echo "Killing any active jamfHelper notifications..."
 killall jamfHelper 2>"/dev/null"
 
 # Clean up plist values.
-echo "Cleaning up all stored plist values..."
-defaults delete "$PLIST" 2>"/dev/null"
+echo "Cleaning up stored plist values..."
+defaults delete "$PLIST" UpdatesForcedAfter 2>/dev/null
+defaults delete "$PLIST" UpdatesDeferredUntil 2>/dev/null
+defaults delete "$PLIST" ThirdPartyUpdatesRestartRequired 2>/dev/null
+defaults delete "$PLIST" ThirdPartyUpdatesRelaunchRequired 2>/dev/null
 
 # Unload LaunchDaemons.
 if [[ -f "$HELPER_LD" ]]; then


### PR DESCRIPTION
- added option for custom `$MAX_DEFERRAL_TIME` and `$SKIP_DEFERRAL` settings defined by plist attributes, or if undefined, reverts to script default (allows for managing deferral periods via configuration profile rather than making the change in the script and repackaging)
- standardized casing (`UpperCamelCase` for CFPreferences, `ALL_CAPS_WITH_UNDERSCORES` for variables)
- split README text in definition lists into multiple paragraphs