### PR TITLE
Adding check if SUCatalog is available

### DIFF
--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -332,13 +332,15 @@ if [[ $? -ne 0 ]]; then
     BAILOUT=true
 fi
 
-# Check if SUCatalog is available
+# Check if a custom CatalogURL is set and if it is available
 SUCatalog=$(python -c 'from Foundation import CFPreferencesCopyAppValue; print CFPreferencesCopyAppValue("CatalogURL", "com.apple.SoftwareUpdate")')
-KernelVersion=$(uname -r)
-curl --user-agent "Darwin/$KernelVersion" -s --head --request GET "$SUCatalog" | grep "200 OK" > /dev/null
-if [[ $? -ne 0 ]]; then
-  echo "[ERROR] SUCatalog can not be reached."
-  BAILOUT=true
+if [ "$SUCatalog" != "None" ]; then
+  KernelVersion=$(uname -r)
+  curl --user-agent "Darwin/$KernelVersion" -s --head --request GET "$SUCatalog" | grep "200 OK" > /dev/null
+  if [[ $? -ne 0 ]]; then
+    echo "[ERROR] SUCatalog can not be reached."
+    BAILOUT=true
+  fi
 fi
 
 # If FileVault encryption or decryption is in progress, installing updates that

--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -330,17 +330,17 @@ ping -q -c 1 208.67.222.222 &>/dev/null
 if [[ $? -ne 0 ]]; then
     echo "[ERROR] No connection to the Internet."
     BAILOUT=true
-fi
-
-# Check if a custom CatalogURL is set and if it is available
-SUCatalog=$(python -c 'from Foundation import CFPreferencesCopyAppValue; print CFPreferencesCopyAppValue("CatalogURL", "com.apple.SoftwareUpdate")')
-if [ "$SUCatalog" != "None" ]; then
-  KernelVersion=$(uname -r)
-  curl --user-agent "Darwin/$KernelVersion" -s --head --request GET "$SUCatalog" | grep "200 OK" > /dev/null
-  if [[ $? -ne 0 ]]; then
-    echo "[ERROR] SUCatalog can not be reached."
-    BAILOUT=true
-  fi
+else
+	# Check if a custom CatalogURL is set and if it is available
+	SUCatalog=$(python -c 'from Foundation import CFPreferencesCopyAppValue; print CFPreferencesCopyAppValue("CatalogURL", "com.apple.SoftwareUpdate")')
+	if [[ "$SUCatalog" != "None" ]]; then
+		KernelVersion=$(uname -r)
+		curl --user-agent "Darwin/$KernelVersion" -s --head "$SUCatalog" | grep "200 OK" > /dev/null
+		if [[ $? -ne 0 ]]; then
+			echo "[ERROR] SUCatalog can not be reached."
+			BAILOUT=true
+		fi
+	fi
 fi
 
 # If FileVault encryption or decryption is in progress, installing updates that

--- a/payload/Library/Scripts/install_or_defer.sh
+++ b/payload/Library/Scripts/install_or_defer.sh
@@ -332,6 +332,15 @@ if [[ $? -ne 0 ]]; then
     BAILOUT=true
 fi
 
+# Check if SUCatalog is available
+SUCatalog=$(python -c 'from Foundation import CFPreferencesCopyAppValue; print CFPreferencesCopyAppValue("CatalogURL", "com.apple.SoftwareUpdate")')
+KernelVersion=$(uname -r)
+curl --user-agent "Darwin/$KernelVersion" -s --head --request GET "$SUCatalog" | grep "200 OK" > /dev/null
+if [[ $? -ne 0 ]]; then
+  echo "[ERROR] SUCatalog can not be reached."
+  BAILOUT=true
+fi
+
 # If FileVault encryption or decryption is in progress, installing updates that
 # require a restart can cause problems.
 if fdesetup status | grep -q "in progress"; then


### PR DESCRIPTION
Adding in an additional check to see if the SUCatalog is available.
Makes sense if your SUS is only available on an internal network,
as a client can be outside of your network, have internet available, but not be able to reach the internal SUS.
Without this check, the clean_up function would run and remove the LD and PLIST.