### PR TITLE
added macOS Sequoia support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This framework is distributed in the form of a [munkipkg](https://github.com/mun
 
 Here's what needs to be in place in order to use this framework:
 
-- The current version of this framework officially supports __macOS Big Sur, Monterey, Ventura, and Sonoma__, but older script versions should continue to function normally for previous macOS releases (note, however, that those versions of macOS are no longer receiving regular security updates from Apple and thus may not benefit from this framework).
+- The current version of this framework officially supports __macOS Monterey, Ventura, Sonoma, and Sequoia__, but older script versions should continue to function normally for previous macOS releases (note, however, that those versions of macOS are no longer receiving regular security updates from Apple and thus may not benefit from this framework).
 - Target Macs must be __enrolled in Jamf Pro__ and have the `jamfHelper` binary installed.
 
 ### Optional
@@ -59,7 +59,7 @@ The framework has a few limitations of note:
 - Reasonable attempts have been made to make this workflow enforceable, but there's nothing stopping an administrator of a Mac from unloading the LaunchDaemon or resetting the preference file.
 - On Apple Silicon Macs, running `softwareupdate --download` and `softwareupdate --install` via background script are unsupported. When this framework is run on an Apple Silicon Mac, enforcement instead takes a "softer" form, opening Software Update and leaving a persistent prompt in place until the updates are applied. Note that this workflow requires the Software Update preference pane to be available to a user with a [secure token and volume ownership](https://support.apple.com/guide/deployment/use-secure-and-bootstrap-tokens-dep24dbdcf9e/), so that they can apply available software updates and restart their Mac.
 - macOS will occasionally present major macOS upgrades (such as macOS Sonoma) on Macs running previous releases, even if an MDM profile deferring major updates is in place. The suggested workaround is to also defer minor updates (possibly for a shorter period) until you can approve the major upgrade in your environment. This script will remove Sonoma as a listed update when on macOS Ventura or older, but if the Mac sees multiple updates requiring restart, the deferred update may still be installed.
-- macOS Big Sur, macOS Monterey, and macOS Ventura (prior to version 13.3) had known reliability issues when attempting to update your Mac using the `softwareupdate` binary, resulting in inconsistently presenting new updates as available or failing to install updates. Some measures have been taken to improve the reliability of this script when encountering these issues, but the recommendation for a fix is to upgrade to the current supported macOS release, as Apple is no longer providing bug fixes for these macOS versions beyond security patches.
+- macOS versions prior to 13.3 had known reliability issues when attempting to update your Mac using the `softwareupdate` binary, resulting in inconsistently presenting new updates as available or failing to install updates. Some measures have been taken to improve the reliability of this script when encountering these issues, but the recommendation for a fix is to upgrade to the current supported macOS release, as Apple is no longer providing bug fixes for these macOS versions beyond security patches.
 
 
 ## Settings customization

--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>7.0</string>
+	<string>7.0.1</string>
 </dict>
 </plist>

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -2,8 +2,7 @@
 
 MAIN_LD="${3}/Library/LaunchDaemons/com.github.mpanighetti.install-or-defer.plist"
 
-# Set ownership and permissions on LaunchDaemon (in case files were modified
-# prior to distribution and ownership/permissions were not properly set).
+# Set ownership and permissions on LaunchDaemon (in case files were modified prior to distribution and ownership/permissions were not properly set).
 /usr/sbin/chown root:wheel "$MAIN_LD"
 /bin/chmod 644 "$MAIN_LD"
 

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -8,8 +8,7 @@ remove_resource () {
     if [ -e "$1" ]; then
         if  echo "$1" | /usr/bin/grep -q ".plist"; then
             PLIST_LABEL=$(/usr/bin/basename "$1" | /usr/bin/awk -F.plist '{print $1}')
-            # If plist is loaded as a LaunchDaemon,
-            # remove the launchd task before file deletion.
+            # If plist is loaded as a LaunchDaemon, remove the launchd task before file deletion.
             if /bin/launchctl list | /usr/bin/grep -q "$PLIST_LABEL"; then
                 /bin/launchctl remove "$PLIST_LABEL"
                 echo "Removed LaunchDaemon: ${PLIST_LABEL}"


### PR DESCRIPTION
- added macOS Sequoia support
- removed macOS Big Sur support
- unblocked newer macOS releases from being supported by the script (replaced with a warning message that the newer release is untested and an invite to submit issues or PRs to fix)
- removed major upgrade deferral bypass logic (no issues reported with macOS Sequoia post-maximum deferral period)